### PR TITLE
Add attachments option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The formatter is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add attachments option ([#19](https://github.com/cucumber/pretty-formatter/pull/19))
 
 ## [2.0.1] - 2025-07-19
 

--- a/java/src/main/java/io/cucumber/prettyformatter/MessagesToPrettyWriter.java
+++ b/java/src/main/java/io/cucumber/prettyformatter/MessagesToPrettyWriter.java
@@ -88,7 +88,12 @@ public final class MessagesToPrettyWriter implements AutoCloseable {
         /**
          * Adds a status icon next to each step line.
          */
-        USE_STATUS_ICON
+        USE_STATUS_ICON,
+
+        /**
+         * Include attachment lines.
+         */
+        INCLUDE_ATTACHMENTS
     }
 
     public static final class Builder {

--- a/java/src/main/java/io/cucumber/prettyformatter/MessagesToPrettyWriter.java
+++ b/java/src/main/java/io/cucumber/prettyformatter/MessagesToPrettyWriter.java
@@ -8,6 +8,7 @@ import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Function;
 
+import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.INCLUDE_ATTACHMENTS;
 import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.INCLUDE_FEATURE_LINE;
 import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.INCLUDE_RULE_LINE;
 import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.USE_STATUS_ICON;
@@ -101,7 +102,8 @@ public final class MessagesToPrettyWriter implements AutoCloseable {
         private final EnumSet<PrettyFeature> features = EnumSet.of(
                 INCLUDE_FEATURE_LINE,
                 INCLUDE_RULE_LINE,
-                USE_STATUS_ICON
+                USE_STATUS_ICON,
+                INCLUDE_ATTACHMENTS
         );
         private Theme theme = Theme.none();
         private Function<String, String> uriFormatter = Function.identity();

--- a/java/src/main/java/io/cucumber/prettyformatter/PrettyReportWriter.java
+++ b/java/src/main/java/io/cucumber/prettyformatter/PrettyReportWriter.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static io.cucumber.messages.types.TestStepResultStatus.FAILED;
+import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.INCLUDE_ATTACHMENTS;
 import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.INCLUDE_FEATURE_LINE;
 import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.INCLUDE_RULE_LINE;
 import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.USE_STATUS_ICON;
@@ -257,6 +258,9 @@ class PrettyReportWriter implements AutoCloseable {
     }
 
     void handleAttachment(Attachment attachment) {
+        if (!features.contains(INCLUDE_ATTACHMENTS)) {
+            return;
+        }
         writer.println();
         switch (attachment.getContentEncoding()) {
             case BASE64:

--- a/java/src/test/java/io/cucumber/prettyformatter/MessagesToPrettyWriterAcceptanceTest.java
+++ b/java/src/test/java/io/cucumber/prettyformatter/MessagesToPrettyWriterAcceptanceTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.cucumber.prettyformatter.Jackson.OBJECT_MAPPER;
+import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.INCLUDE_ATTACHMENTS;
 import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.INCLUDE_FEATURE_LINE;
 import static io.cucumber.prettyformatter.MessagesToPrettyWriter.PrettyFeature.INCLUDE_RULE_LINE;
 import static io.cucumber.prettyformatter.MessagesToPrettyWriter.builder;
@@ -45,6 +46,9 @@ class MessagesToPrettyWriterAcceptanceTest {
                 .theme(none())
                 .feature(INCLUDE_RULE_LINE, false)
                 .feature(INCLUDE_FEATURE_LINE, false));
+        themes.put("exclude-attachments", builder()
+                .theme(none())
+                .feature(INCLUDE_ATTACHMENTS, false));
 
         List<Path> sources = getSources();
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -20,6 +20,7 @@ For usage in `@cucumber/cucumber`, see https://github.com/cucumber/cucumber-js/b
 
 ## Options
 
+- `attachments` - whether to include attachments (defaults to `true`)
 - `featuresAndRules` - whether to include headings for Features and Rules (defaults to `true`)
 - `theme` - control over the styling of various elements (see below)
 

--- a/javascript/src/PrettyPrinter.ts
+++ b/javascript/src/PrettyPrinter.ts
@@ -327,6 +327,9 @@ export class PrettyPrinter {
   }
 
   private handleAttachment(attachment: Attachment) {
+    if (!this.options.attachments) {
+      return
+    }
     const scenarioIndent = this.getScenarioIndentBy(attachment)
     const content = formatAttachment(attachment, this.options.theme, this.stream)
     this.println(

--- a/javascript/src/index.spec.ts
+++ b/javascript/src/index.spec.ts
@@ -87,7 +87,7 @@ describe('Acceptance Tests', async function () {
     {
       name: 'exclude-features-and-rules',
       options: {
-        attachments: false,
+        attachments: true,
         featuresAndRules: false,
         theme: {},
       },
@@ -95,8 +95,8 @@ describe('Acceptance Tests', async function () {
     {
       name: 'exclude-attachments',
       options: {
-        attachments: true,
-        featuresAndRules: false,
+        attachments: false,
+        featuresAndRules: true,
         theme: {},
       },
     },

--- a/javascript/src/index.spec.ts
+++ b/javascript/src/index.spec.ts
@@ -71,6 +71,7 @@ describe('Acceptance Tests', async function () {
     {
       name: 'cucumber',
       options: {
+        attachments: true,
         featuresAndRules: true,
         theme: CUCUMBER_THEME,
       },
@@ -78,6 +79,7 @@ describe('Acceptance Tests', async function () {
     {
       name: 'demo',
       options: {
+        attachments: true,
         featuresAndRules: true,
         theme: DEMO_THEME,
       },
@@ -85,6 +87,15 @@ describe('Acceptance Tests', async function () {
     {
       name: 'exclude-features-and-rules',
       options: {
+        attachments: false,
+        featuresAndRules: false,
+        theme: {},
+      },
+    },
+    {
+      name: 'exclude-attachments',
+      options: {
+        attachments: true,
         featuresAndRules: false,
         theme: {},
       },
@@ -92,6 +103,7 @@ describe('Acceptance Tests', async function () {
     {
       name: 'none',
       options: {
+        attachments: true,
         featuresAndRules: true,
         theme: {},
       },
@@ -99,6 +111,7 @@ describe('Acceptance Tests', async function () {
     {
       name: 'plain',
       options: {
+        attachments: true,
         featuresAndRules: true,
         theme: {
           status: {

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -5,6 +5,7 @@ import { CUCUMBER_THEME } from './theme.js'
 import type { Options } from './types.js'
 
 const DEFAULT_OPTIONS: Required<Options> = {
+  attachments: true,
   featuresAndRules: true,
   theme: CUCUMBER_THEME,
 }

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -47,6 +47,7 @@ export interface Theme {
 }
 
 export interface Options {
+  attachments?: boolean
   featuresAndRules?: boolean
   theme?: Theme
 }

--- a/testdata/attachments.exclude-attachments.log
+++ b/testdata/attachments.exclude-attachments.log
@@ -1,0 +1,26 @@
+
+Feature: Attachments
+
+  Scenario: Strings can be attached with a media type                 # samples/attachments/attachments.feature:11
+    When the string "hello" is attached as "application/octet-stream" # samples/attachments/attachments.ts:4
+
+  Scenario: Log text                  # samples/attachments/attachments.feature:17
+    When the string "hello" is logged # samples/attachments/attachments.ts:8
+
+  Scenario: Log ANSI coloured text        # samples/attachments/attachments.feature:20
+    When text with ANSI escapes is logged # samples/attachments/attachments.ts:12
+
+  Scenario: Log JSON                                             # samples/attachments/attachments.feature:23
+    When the following string is attached as "application/json": # samples/attachments/attachments.ts:18
+      """
+      {"message": "The <b>big</b> question", "foo": "bar"}
+      """
+
+  Scenario: Byte arrays are base64-encoded regardless of media type # samples/attachments/attachments.feature:29
+    When an array with 10 bytes is attached as "text/plain"         # samples/attachments/attachments.ts:22
+
+  Scenario: Attaching PDFs with a different filename # samples/attachments/attachments.feature:32
+    When a PDF document is attached and renamed      # samples/attachments/attachments.ts:31
+
+  Scenario: Attaching URIs                           # samples/attachments/attachments.feature:35
+    When a link to "https://cucumber.io" is attached # samples/attachments/attachments.ts:38

--- a/testdata/cdata.exclude-attachments.log
+++ b/testdata/cdata.exclude-attachments.log
@@ -1,0 +1,5 @@
+
+Feature: cdata
+
+  Scenario: cdata                                 # samples/cdata/cdata.feature:4
+    Given I have 42 <![CDATA[cukes]]> in my belly # samples/cdata/cdata.ts:3

--- a/testdata/data-tables.exclude-attachments.log
+++ b/testdata/data-tables.exclude-attachments.log
@@ -1,0 +1,10 @@
+
+Feature: Data Tables
+
+  Scenario: transposed table                # samples/data-tables/data-tables.feature:7
+    When the following table is transposed: # samples/data-tables/data-tables.ts:4
+      | a | b |
+      | 1 | 2 |
+    Then it should be:                      # samples/data-tables/data-tables.ts:8
+      | a | 1 |
+      | b | 2 |

--- a/testdata/empty.exclude-attachments.log
+++ b/testdata/empty.exclude-attachments.log
@@ -1,0 +1,4 @@
+
+Feature: Empty Scenarios
+
+  Scenario: Blank Scenario # samples/empty/empty.feature:7

--- a/testdata/examples-tables-attachment.exclude-attachments.log
+++ b/testdata/examples-tables-attachment.exclude-attachments.log
@@ -1,0 +1,8 @@
+
+Feature: Examples Tables - With attachments
+
+  Scenario Outline: Attaching images in an examples table # samples/examples-tables-attachment/examples-tables-attachment.feature:9
+    When a JPEG image is attached                         # samples/examples-tables-attachment/examples-tables-attachment.ts:4
+
+  Scenario Outline: Attaching images in an examples table # samples/examples-tables-attachment/examples-tables-attachment.feature:10
+    When a PNG image is attached                          # samples/examples-tables-attachment/examples-tables-attachment.ts:8

--- a/testdata/examples-tables.exclude-attachments.log
+++ b/testdata/examples-tables.exclude-attachments.log
@@ -1,0 +1,55 @@
+
+Feature: Examples Tables
+
+  @passing
+  Scenario Outline: Eating cucumbers # samples/examples-tables/examples-tables.feature:19
+    Given there are 12 cucumbers     # samples/examples-tables/examples-tables.ts:4
+    When I eat 5 cucumbers           # samples/examples-tables/examples-tables.ts:12
+    Then I should have 7 cucumbers   # samples/examples-tables/examples-tables.ts:16
+
+  @passing
+  Scenario Outline: Eating cucumbers # samples/examples-tables/examples-tables.feature:20
+    Given there are 20 cucumbers     # samples/examples-tables/examples-tables.ts:4
+    When I eat 5 cucumbers           # samples/examples-tables/examples-tables.ts:12
+    Then I should have 15 cucumbers  # samples/examples-tables/examples-tables.ts:16
+
+  @failing
+  Scenario Outline: Eating cucumbers # samples/examples-tables/examples-tables.feature:25
+    Given there are 12 cucumbers     # samples/examples-tables/examples-tables.ts:4
+    When I eat 20 cucumbers          # samples/examples-tables/examples-tables.ts:12
+    Then I should have 0 cucumbers   # samples/examples-tables/examples-tables.ts:16
+        samples/examples-tables/examples-tables.feature:14
+
+  @failing
+  Scenario Outline: Eating cucumbers # samples/examples-tables/examples-tables.feature:26
+    Given there are 0 cucumbers      # samples/examples-tables/examples-tables.ts:4
+    When I eat 1 cucumbers           # samples/examples-tables/examples-tables.ts:12
+    Then I should have 0 cucumbers   # samples/examples-tables/examples-tables.ts:16
+        samples/examples-tables/examples-tables.feature:14
+
+  @undefined
+  Scenario Outline: Eating cucumbers # samples/examples-tables/examples-tables.feature:31
+    Given there are 12 cucumbers     # samples/examples-tables/examples-tables.ts:4
+    When I eat banana cucumbers
+    Then I should have 12 cucumbers  # samples/examples-tables/examples-tables.ts:16
+
+  @undefined
+  Scenario Outline: Eating cucumbers   # samples/examples-tables/examples-tables.feature:32
+    Given there are 0 cucumbers        # samples/examples-tables/examples-tables.ts:4
+    When I eat 1 cucumbers             # samples/examples-tables/examples-tables.ts:12
+    Then I should have apple cucumbers
+
+  Scenario Outline: Eating cucumbers with 11 friends # samples/examples-tables/examples-tables.feature:41
+    Given there are 11 friends                       # samples/examples-tables/examples-tables.ts:8
+    And there are 12 cucumbers                       # samples/examples-tables/examples-tables.ts:4
+    Then each person can eat 1 cucumbers             # samples/examples-tables/examples-tables.ts:20
+
+  Scenario Outline: Eating cucumbers with 1 friends # samples/examples-tables/examples-tables.feature:42
+    Given there are 1 friends                       # samples/examples-tables/examples-tables.ts:8
+    And there are 4 cucumbers                       # samples/examples-tables/examples-tables.ts:4
+    Then each person can eat 2 cucumbers            # samples/examples-tables/examples-tables.ts:20
+
+  Scenario Outline: Eating cucumbers with 0 friends # samples/examples-tables/examples-tables.feature:43
+    Given there are 0 friends                       # samples/examples-tables/examples-tables.ts:8
+    And there are 4 cucumbers                       # samples/examples-tables/examples-tables.ts:4
+    Then each person can eat 4 cucumbers            # samples/examples-tables/examples-tables.ts:20

--- a/testdata/hooks-attachment.exclude-attachments.log
+++ b/testdata/hooks-attachment.exclude-attachments.log
@@ -1,0 +1,5 @@
+
+Feature: Hooks - Attachments
+
+  Scenario: With an valid attachment in the hook and a passed step # samples/hooks-attachment/hooks-attachment.feature:6
+    When a step passes                                             # samples/hooks-attachment/hooks-attachment.ts:9

--- a/testdata/hooks-conditional.exclude-attachments.log
+++ b/testdata/hooks-conditional.exclude-attachments.log
@@ -1,0 +1,16 @@
+
+Feature: Hooks - Conditional execution
+
+  @fail-before
+  Scenario: A failure in the before hook and a skipped step # samples/hooks-conditional/hooks-conditional.feature:7
+        samples/hooks-conditional/hooks-conditional.feature:7
+    When a step passes                                      # samples/hooks-conditional/hooks-conditional.ts:11
+
+  @fail-after
+  Scenario: A failure in the after hook and a passed step # samples/hooks-conditional/hooks-conditional.feature:11
+    When a step passes                                    # samples/hooks-conditional/hooks-conditional.ts:11
+        samples/hooks-conditional/hooks-conditional.feature:11
+
+  @passing-hook
+  Scenario: With an tag, a passed step and hook # samples/hooks-conditional/hooks-conditional.feature:15
+    When a step passes                          # samples/hooks-conditional/hooks-conditional.ts:11

--- a/testdata/hooks-named.exclude-attachments.log
+++ b/testdata/hooks-named.exclude-attachments.log
@@ -1,0 +1,5 @@
+
+Feature: Hooks - Named
+
+  Scenario: With a named before and after hook # samples/hooks-named/hooks-named.feature:7
+    When a step passes                         # samples/hooks-named/hooks-named.ts:7

--- a/testdata/hooks.exclude-attachments.log
+++ b/testdata/hooks.exclude-attachments.log
@@ -1,0 +1,12 @@
+
+Feature: Hooks
+
+  Scenario: No tags and a passed step # samples/hooks/hooks.feature:4
+    When a step passes                # samples/hooks/hooks.ts:7
+
+  Scenario: No tags and a failed step # samples/hooks/hooks.feature:7
+    When a step fails                 # samples/hooks/hooks.ts:11
+        samples/hooks/hooks.feature:8
+
+  Scenario: No tags and a undefined step # samples/hooks/hooks.feature:10
+    When a step does not exist

--- a/testdata/markdown.exclude-attachments.log
+++ b/testdata/markdown.exclude-attachments.log
@@ -1,0 +1,37 @@
+
+Feature: Cheese
+
+  Rule: Nom nom nom
+
+    Scenario Outline: Ylajali!                                    # samples/markdown/markdown.feature.md:38
+      Given some TypeScript code:                                 # samples/markdown/markdown.ts:4
+        """typescript
+        type Cheese = 'reblochon' | 'roquefort' | 'rocamadour'
+        """
+      And some classic Gherkin:                                   # samples/markdown/markdown.ts:8
+        """gherkin
+        Given there are 24 apples in Mary's basket
+        """
+      When we use a data table and attach something and then fail # samples/markdown/markdown.ts:12
+        | name | age |
+        | Bill | 3   |
+        | Jane | 6   |
+        | Isla | 5   |
+          samples/markdown/markdown.feature.md:24
+      Then this might or might not run                            # samples/markdown/markdown.ts:23
+
+    Scenario Outline: Ylajali!                                    # samples/markdown/markdown.feature.md:39
+      Given some TypeScript code:                                 # samples/markdown/markdown.ts:4
+        """typescript
+        type Cheese = 'reblochon' | 'roquefort' | 'rocamadour'
+        """
+      And some classic Gherkin:                                   # samples/markdown/markdown.ts:8
+        """gherkin
+        Given there are 24 apples in Mary's basket
+        """
+      When we use a data table and attach something and then pass # samples/markdown/markdown.ts:12
+        | name | age |
+        | Bill | 3   |
+        | Jane | 6   |
+        | Isla | 5   |
+      Then this might or might not run                            # samples/markdown/markdown.ts:23

--- a/testdata/minimal.exclude-attachments.log
+++ b/testdata/minimal.exclude-attachments.log
@@ -1,0 +1,5 @@
+
+Feature: minimal
+
+  Scenario: cukes                     # samples/minimal/minimal.feature:9
+    Given I have 42 cukes in my belly # samples/minimal/minimal.ts:3

--- a/testdata/parameter-types.exclude-attachments.log
+++ b/testdata/parameter-types.exclude-attachments.log
@@ -1,0 +1,5 @@
+
+Feature: Parameter Types
+
+  Scenario: Flight transformer     # samples/parameter-types/parameter-types.feature:10
+    Given LHR-CDG has been delayed # samples/parameter-types/parameter-types.ts:16

--- a/testdata/pending.exclude-attachments.log
+++ b/testdata/pending.exclude-attachments.log
@@ -1,0 +1,13 @@
+
+Feature: Pending steps
+
+  Scenario: Unimplemented step signals pending status # samples/pending/pending.feature:9
+    Given an unimplemented pending step               # samples/pending/pending.ts:11
+
+  Scenario: Steps before unimplemented steps are executed # samples/pending/pending.feature:12
+    Given an implemented non-pending step                 # samples/pending/pending.ts:3
+    And an unimplemented pending step                     # samples/pending/pending.ts:11
+
+  Scenario: Steps after unimplemented steps are skipped # samples/pending/pending.feature:16
+    Given an unimplemented pending step                 # samples/pending/pending.ts:11
+    And an implemented step that is skipped             # samples/pending/pending.ts:7

--- a/testdata/retry.exclude-attachments.log
+++ b/testdata/retry.exclude-attachments.log
@@ -1,0 +1,38 @@
+
+Feature: Retry
+
+  Scenario: Test cases that pass aren't retried # samples/retry/retry.feature:8
+    Given a step that always passes             # samples/retry/retry.ts:3
+
+  Scenario: Test cases that fail are retried if within the --retry limit # samples/retry/retry.feature:11
+    Given a step that passes the second time                             # samples/retry/retry.ts:8
+        samples/retry/retry.feature:12
+
+  Scenario: Test cases that fail are retried if within the --retry limit # samples/retry/retry.feature:11
+    Given a step that passes the second time                             # samples/retry/retry.ts:8
+
+  Scenario: Test cases that fail will continue to retry up to the --retry limit # samples/retry/retry.feature:14
+    Given a step that passes the third time                                     # samples/retry/retry.ts:16
+        samples/retry/retry.feature:15
+
+  Scenario: Test cases that fail will continue to retry up to the --retry limit # samples/retry/retry.feature:14
+    Given a step that passes the third time                                     # samples/retry/retry.ts:16
+        samples/retry/retry.feature:15
+
+  Scenario: Test cases that fail will continue to retry up to the --retry limit # samples/retry/retry.feature:14
+    Given a step that passes the third time                                     # samples/retry/retry.ts:16
+
+  Scenario: Test cases won't retry after failing more than the --retry limit # samples/retry/retry.feature:17
+    Given a step that always fails                                           # samples/retry/retry.ts:23
+        samples/retry/retry.feature:18
+
+  Scenario: Test cases won't retry after failing more than the --retry limit # samples/retry/retry.feature:17
+    Given a step that always fails                                           # samples/retry/retry.ts:23
+        samples/retry/retry.feature:18
+
+  Scenario: Test cases won't retry after failing more than the --retry limit # samples/retry/retry.feature:17
+    Given a step that always fails                                           # samples/retry/retry.ts:23
+        samples/retry/retry.feature:18
+
+  Scenario: Test cases won't retry when the status is UNDEFINED # samples/retry/retry.feature:20
+    Given a non-existent step

--- a/testdata/rules.exclude-attachments.log
+++ b/testdata/rules.exclude-attachments.log
@@ -1,0 +1,25 @@
+
+Feature: Usage of a `Rule`
+
+  Rule: A sale cannot happen if the customer does not have enough money
+
+    Example: Not enough money                                 # samples/rules/rules.feature:9
+      Given the customer has 100 cents                        # samples/rules/rules.ts:4
+      And there are chocolate bars in stock                   # samples/rules/rules.ts:8
+      When the customer tries to buy a 125 cent chocolate bar # samples/rules/rules.ts:16
+      Then the sale should not happen                         # samples/rules/rules.ts:22
+
+    Example: Enough money                                    # samples/rules/rules.feature:16
+      Given the customer has 100 cents                       # samples/rules/rules.ts:4
+      And there are chocolate bars in stock                  # samples/rules/rules.ts:8
+      When the customer tries to buy a 75 cent chocolate bar # samples/rules/rules.ts:16
+      Then the sale should happen                            # samples/rules/rules.ts:26
+
+  Rule: a sale cannot happen if there is no stock
+
+    @some-tag
+    Example: No chocolates left                             # samples/rules/rules.feature:25
+      Given the customer has 100 cents                      # samples/rules/rules.ts:4
+      And there are no chocolate bars in stock              # samples/rules/rules.ts:12
+      When the customer tries to buy a 1 cent chocolate bar # samples/rules/rules.ts:16
+      Then the sale should not happen                       # samples/rules/rules.ts:22

--- a/testdata/skipped.exclude-attachments.log
+++ b/testdata/skipped.exclude-attachments.log
@@ -1,0 +1,14 @@
+
+Feature: Skipping scenarios
+
+  @skip
+  Scenario: Skipping from a Before hook # samples/skipped/skipped.feature:10
+    Given a step that is skipped        # samples/skipped/skipped.ts:11
+
+  Scenario: Skipping from a step doesn't affect the previous steps # samples/skipped/skipped.feature:13
+    Given a step that does not skip                                # samples/skipped/skipped.ts:7
+    And I skip a step                                              # samples/skipped/skipped.ts:15
+
+  Scenario: Skipping from a step causes the rest of the scenario to be skipped # samples/skipped/skipped.feature:17
+    Given I skip a step                                                        # samples/skipped/skipped.ts:15
+    And a step that is skipped                                                 # samples/skipped/skipped.ts:11

--- a/testdata/stack-traces.exclude-attachments.log
+++ b/testdata/stack-traces.exclude-attachments.log
@@ -1,0 +1,6 @@
+
+Feature: Stack traces
+
+  Scenario: A failing step          # samples/stack-traces/stack-traces.feature:9
+    When a step throws an exception # samples/stack-traces/stack-traces.ts:3
+        samples/stack-traces/stack-traces.feature:10

--- a/testdata/undefined.exclude-attachments.log
+++ b/testdata/undefined.exclude-attachments.log
@@ -1,0 +1,13 @@
+
+Feature: Undefined steps
+
+  Scenario: An undefined step causes a failure # samples/undefined/undefined.feature:8
+    Given a step that is yet to be defined
+
+  Scenario: Steps before undefined steps are executed # samples/undefined/undefined.feature:11
+    Given an implemented step                         # samples/undefined/undefined.ts:3
+    And a step that is yet to be defined
+
+  Scenario: Steps after undefined steps are skipped # samples/undefined/undefined.feature:15
+    Given a step that is yet to be defined
+    And a step that will be skipped                 # samples/undefined/undefined.ts:7

--- a/testdata/unknown-parameter-type.exclude-attachments.log
+++ b/testdata/unknown-parameter-type.exclude-attachments.log
@@ -1,0 +1,5 @@
+
+Feature: Parameter Types
+
+  Scenario: undefined parameter type        # samples/unknown-parameter-type/unknown-parameter-type.feature:5
+    Given CDG is closed because of a strike


### PR DESCRIPTION
### 🤔 What's changed?

Add an option for whether to include attachments, enabled by default for backwards compatibility.

### ⚡️ What's your motivation? 

Part of https://github.com/cucumber/cucumber-js/issues/2620

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
