### PR TITLE
Fix step match arguments highlighting for ambiguous steps

### DIFF
--- a/java/src/main/java/io/cucumber/prettyformatter/PrettyReportWriter.java
+++ b/java/src/main/java/io/cucumber/prettyformatter/PrettyReportWriter.java
@@ -10,6 +10,7 @@ import io.cucumber.messages.types.Rule;
 import io.cucumber.messages.types.Scenario;
 import io.cucumber.messages.types.Step;
 import io.cucumber.messages.types.StepMatchArgument;
+import io.cucumber.messages.types.StepMatchArgumentsList;
 import io.cucumber.messages.types.TestCaseStarted;
 import io.cucumber.messages.types.TestRunFinished;
 import io.cucumber.messages.types.TestStep;
@@ -219,6 +220,7 @@ final class PrettyReportWriter implements AutoCloseable {
     private List<StepMatchArgument> getStepMatchArguments(TestStep testStep) {
         List<StepMatchArgument> stepMatchArguments = new ArrayList<>();
         testStep.getStepMatchArgumentsLists()
+                .filter(stepMatchArgumentsList -> stepMatchArgumentsList.size() == 1)
                 .orElse(emptyList())
                 .forEach(list -> stepMatchArguments.addAll(list.getStepMatchArguments()));
         return stepMatchArguments;


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Only unambiguous steps, i.e. steps with a single list of matches should be highlighted.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

- [ ] https://github.com/cucumber/compatibility-kit/pull/156 for verification
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
