### PR TITLE
Use singular noun in summary when count is 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The formatter is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use singular noun in summary when count is 1 ([#100](https://github.com/cucumber/pretty-formatter/pull/100))
 
 ## [3.3.0] - 2026-05-03
 ### Added

--- a/java/src/main/java/io/cucumber/prettyformatter/SummaryReportWriter.java
+++ b/java/src/main/java/io/cucumber/prettyformatter/SummaryReportWriter.java
@@ -421,6 +421,7 @@ final class SummaryReportWriter implements AutoCloseable {
         }
 
         out.println(formatSubCounts(
+                "hook",
                 "hooks",
                 testRunHooksFinished,
                 countTestStepResultStatusByTestRunHookFinished()));
@@ -429,6 +430,7 @@ final class SummaryReportWriter implements AutoCloseable {
 
     private void printScenarioCounts() {
         out.println(formatSubCounts(
+                "scenario",
                 "scenarios",
                 query.findAllTestCaseFinished(),
                 countTestStepResultStatusByTestCaseFinished()));
@@ -436,6 +438,7 @@ final class SummaryReportWriter implements AutoCloseable {
 
     private void printStepCounts() {
         out.println(formatSubCounts(
+                "step",
                 "steps",
                 // findAllTestCaseFinished excludes non-final test cases
                 // This ensures findTestStepsFinishedBy does not include retried steps
@@ -447,11 +450,13 @@ final class SummaryReportWriter implements AutoCloseable {
     }
 
     private <T> String formatSubCounts(
-            String itemName,
+            String singular,
+            String plural,
             Collection<T> finishedItems,
             Collector<T, ?, Map<TestStepResultStatus, Long>> countTestStepResultStatusByItem
     ) {
-        String countAndName = finishedItems.size() + " " + itemName;
+        int size = finishedItems.size();
+        String countAndName = size + " " + (size == 1 ? singular : plural);
         StringJoiner joiner = new StringJoiner(", ", countAndName + " (", ")");
         joiner.setEmptyValue(countAndName);
         Map<TestStepResultStatus, Long> subCounts = finishedItems.stream()

--- a/javascript/src/composition/composeStats.ts
+++ b/javascript/src/composition/composeStats.ts
@@ -12,7 +12,7 @@ export function composeStats(query: Query, theme: Theme, stream: NodeJS.Writable
     lines.push('')
     lines.push(
       formatCounts(
-        'test run',
+        ['test run', 'test runs'],
         {
           [TestStepResultStatus.FAILED]: 1,
         },
@@ -33,7 +33,7 @@ export function composeStats(query: Query, theme: Theme, stream: NodeJS.Writable
         },
         {} as Partial<Record<TestStepResultStatus, number>>
       )
-    lines.push(formatCounts('hooks', globalHookCountsByStatus, theme, stream))
+    lines.push(formatCounts(['hook', 'hooks'], globalHookCountsByStatus, theme, stream))
   }
 
   const scenarioCountsByStatus = query
@@ -47,7 +47,7 @@ export function composeStats(query: Query, theme: Theme, stream: NodeJS.Writable
       },
       {} as Partial<Record<TestStepResultStatus, number>>
     )
-  lines.push(formatCounts('scenarios', scenarioCountsByStatus, theme, stream))
+  lines.push(formatCounts(['scenario', 'scenarios'], scenarioCountsByStatus, theme, stream))
 
   const stepCountsByStatus = query
     .findAllTestCaseFinished()
@@ -60,7 +60,7 @@ export function composeStats(query: Query, theme: Theme, stream: NodeJS.Writable
       },
       {} as Partial<Record<TestStepResultStatus, number>>
     )
-  lines.push(formatCounts('steps', stepCountsByStatus, theme, stream))
+  lines.push(formatCounts(['step', 'steps'], stepCountsByStatus, theme, stream))
 
   const testRunDuration = query.findTestRunDuration()
   if (testRunDuration) {

--- a/javascript/src/formatting/formatCounts.ts
+++ b/javascript/src/formatting/formatCounts.ts
@@ -5,14 +5,14 @@ import type { Theme } from '../types'
 import { ORDERED_STATUSES } from '../utils'
 
 export function formatCounts(
-  suffix: string,
+  noun: readonly [singular: string, plural: string],
   counts: Partial<Record<TestStepResultStatus, number>>,
   theme: Theme,
   stream: NodeJS.WritableStream
 ): string {
   const builder = new TextBuilder(stream)
   const total = Object.values(counts).reduce((prev, curr) => prev + curr, 0)
-  builder.append(`${total} ${suffix}`)
+  builder.append(`${total} ${total === 1 ? noun[0] : noun[1]}`)
   if (total > 0) {
     let first = true
     builder.append(' (')

--- a/testdata/src/ambiguous.cucumber.progressbar.log
+++ b/testdata/src/ambiguous.cucumber.progressbar.log
@@ -42,7 +42,7 @@
                • ^a (.*?) with (.*?)$ [90m# samples/ambiguous/ambiguous.ts:3[39m
                • ^a step with (.*?)$ [90m# samples/ambiguous/ambiguous.ts:7[39m
   
-  1 scenarios ([35m1 ambiguous[39m)
-  1 steps ([35m1 ambiguous[39m)
+  1 scenario ([35m1 ambiguous[39m)
+  1 step ([35m1 ambiguous[39m)
   0m 0.5s (0m 0.0s executing your code)
   

--- a/testdata/src/ambiguous.cucumber.summary.log
+++ b/testdata/src/ambiguous.cucumber.summary.log
@@ -6,6 +6,6 @@
              • ^a (.*?) with (.*?)$ [90m# samples/ambiguous/ambiguous.ts:3[39m
              • ^a step with (.*?)$ [90m# samples/ambiguous/ambiguous.ts:7[39m
 
-1 scenarios ([35m1 ambiguous[39m)
-1 steps ([35m1 ambiguous[39m)
+1 scenario ([35m1 ambiguous[39m)
+1 step ([35m1 ambiguous[39m)
 0m 0.5s (0m 0.0s executing your code)

--- a/testdata/src/ambiguous.exclude-attachments.summary.log
+++ b/testdata/src/ambiguous.exclude-attachments.summary.log
@@ -6,6 +6,6 @@ Ambiguous scenarios:
              - ^a (.*?) with (.*?)$ # samples/ambiguous/ambiguous.ts:3
              - ^a step with (.*?)$ # samples/ambiguous/ambiguous.ts:7
 
-1 scenarios (1 ambiguous)
-1 steps (1 ambiguous)
+1 scenario (1 ambiguous)
+1 step (1 ambiguous)
 0m 0.5s (0m 0.0s executing your code)

--- a/testdata/src/ambiguous.plain.summary.log
+++ b/testdata/src/ambiguous.plain.summary.log
@@ -6,6 +6,6 @@ Ambiguous scenarios:
              - ^a (.*?) with (.*?)$ # samples/ambiguous/ambiguous.ts:3
              - ^a step with (.*?)$ # samples/ambiguous/ambiguous.ts:7
 
-1 scenarios (1 ambiguous)
-1 steps (1 ambiguous)
+1 scenario (1 ambiguous)
+1 step (1 ambiguous)
 0m 0.5s (0m 0.0s executing your code)

--- a/testdata/src/cdata.cucumber.progressbar.log
+++ b/testdata/src/cdata.cucumber.progressbar.log
@@ -30,7 +30,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([32m1 passed[39m)
-  1 steps ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
+  1 step ([32m1 passed[39m)
   0m 0.5s (0m 0.1s executing your code)
   

--- a/testdata/src/cdata.cucumber.summary.log
+++ b/testdata/src/cdata.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([32m1 passed[39m)
-1 steps ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
+1 step ([32m1 passed[39m)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/cdata.exclude-attachments.summary.log
+++ b/testdata/src/cdata.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/cdata.plain.summary.log
+++ b/testdata/src/cdata.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/data-tables.cucumber.progressbar.log
+++ b/testdata/src/data-tables.cucumber.progressbar.log
@@ -36,7 +36,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
   2 steps ([32m2 passed[39m)
   0m 0.7s (0m 0.2s executing your code)
   

--- a/testdata/src/data-tables.cucumber.summary.log
+++ b/testdata/src/data-tables.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
 2 steps ([32m2 passed[39m)
 0m 0.7s (0m 0.2s executing your code)

--- a/testdata/src/data-tables.exclude-attachments.summary.log
+++ b/testdata/src/data-tables.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 2 steps (2 passed)
 0m 0.7s (0m 0.2s executing your code)

--- a/testdata/src/data-tables.plain.summary.log
+++ b/testdata/src/data-tables.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 2 steps (2 passed)
 0m 0.7s (0m 0.2s executing your code)

--- a/testdata/src/empty.cucumber.progressbar.log
+++ b/testdata/src/empty.cucumber.progressbar.log
@@ -24,7 +24,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
   0 steps
   0m 0.3s (0m 0.0s executing your code)
   

--- a/testdata/src/empty.cucumber.summary.log
+++ b/testdata/src/empty.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
 0 steps
 0m 0.3s (0m 0.0s executing your code)

--- a/testdata/src/empty.exclude-attachments.summary.log
+++ b/testdata/src/empty.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 0 steps
 0m 0.3s (0m 0.0s executing your code)

--- a/testdata/src/empty.plain.summary.log
+++ b/testdata/src/empty.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 0 steps
 0m 0.3s (0m 0.0s executing your code)

--- a/testdata/src/global-hooks-afterall-error.cucumber.progressbar.log
+++ b/testdata/src/global-hooks-afterall-error.cucumber.progressbar.log
@@ -45,7 +45,7 @@
          [31msamples/global-hooks-afterall-error/global-hooks-afterall-error.ts:19[39m
   
   5 hooks ([32m4 passed[39m, [31m1 failed[39m)
-  1 scenarios ([32m1 passed[39m)
-  1 steps ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
+  1 step ([32m1 passed[39m)
   0m 0.15s (0m 0.6s executing your code)
   

--- a/testdata/src/global-hooks-afterall-error.cucumber.summary.log
+++ b/testdata/src/global-hooks-afterall-error.cucumber.summary.log
@@ -5,6 +5,6 @@
        [31msamples/global-hooks-afterall-error/global-hooks-afterall-error.ts:19[39m
 
 5 hooks ([32m4 passed[39m, [31m1 failed[39m)
-1 scenarios ([32m1 passed[39m)
-1 steps ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
+1 step ([32m1 passed[39m)
 0m 0.15s (0m 0.6s executing your code)

--- a/testdata/src/global-hooks-afterall-error.exclude-attachments.summary.log
+++ b/testdata/src/global-hooks-afterall-error.exclude-attachments.summary.log
@@ -5,6 +5,6 @@ Failed hooks:
        samples/global-hooks-afterall-error/global-hooks-afterall-error.ts:19
 
 5 hooks (4 passed, 1 failed)
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.15s (0m 0.6s executing your code)

--- a/testdata/src/global-hooks-afterall-error.plain.summary.log
+++ b/testdata/src/global-hooks-afterall-error.plain.summary.log
@@ -5,6 +5,6 @@ Failed hooks:
        samples/global-hooks-afterall-error/global-hooks-afterall-error.ts:19
 
 5 hooks (4 passed, 1 failed)
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.15s (0m 0.6s executing your code)

--- a/testdata/src/global-hooks-attachments.cucumber.progressbar.log
+++ b/testdata/src/global-hooks-attachments.cucumber.progressbar.log
@@ -31,7 +31,7 @@
 [testRunFinished]
   
   2 hooks ([32m2 passed[39m)
-  1 scenarios ([32m1 passed[39m)
-  1 steps ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
+  1 step ([32m1 passed[39m)
   0m 0.11s (0m 0.3s executing your code)
   

--- a/testdata/src/global-hooks-attachments.cucumber.summary.log
+++ b/testdata/src/global-hooks-attachments.cucumber.summary.log
@@ -1,5 +1,5 @@
 
 2 hooks ([32m2 passed[39m)
-1 scenarios ([32m1 passed[39m)
-1 steps ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
+1 step ([32m1 passed[39m)
 0m 0.11s (0m 0.3s executing your code)

--- a/testdata/src/global-hooks-attachments.exclude-attachments.summary.log
+++ b/testdata/src/global-hooks-attachments.exclude-attachments.summary.log
@@ -1,5 +1,5 @@
 
 2 hooks (2 passed)
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.11s (0m 0.3s executing your code)

--- a/testdata/src/global-hooks-attachments.plain.summary.log
+++ b/testdata/src/global-hooks-attachments.plain.summary.log
@@ -1,5 +1,5 @@
 
 2 hooks (2 passed)
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.11s (0m 0.3s executing your code)

--- a/testdata/src/hooks-attachment.cucumber.progressbar.log
+++ b/testdata/src/hooks-attachment.cucumber.progressbar.log
@@ -42,7 +42,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
   3 steps ([32m3 passed[39m)
   0m 0.11s (0m 0.3s executing your code)
   

--- a/testdata/src/hooks-attachment.cucumber.summary.log
+++ b/testdata/src/hooks-attachment.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
 3 steps ([32m3 passed[39m)
 0m 0.11s (0m 0.3s executing your code)

--- a/testdata/src/hooks-attachment.exclude-attachments.summary.log
+++ b/testdata/src/hooks-attachment.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 3 steps (3 passed)
 0m 0.11s (0m 0.3s executing your code)

--- a/testdata/src/hooks-attachment.plain.summary.log
+++ b/testdata/src/hooks-attachment.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 3 steps (3 passed)
 0m 0.11s (0m 0.3s executing your code)

--- a/testdata/src/hooks-named.cucumber.progressbar.log
+++ b/testdata/src/hooks-named.cucumber.progressbar.log
@@ -42,7 +42,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
   3 steps ([32m3 passed[39m)
   0m 0.9s (0m 0.3s executing your code)
   

--- a/testdata/src/hooks-named.cucumber.summary.log
+++ b/testdata/src/hooks-named.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
 3 steps ([32m3 passed[39m)
 0m 0.9s (0m 0.3s executing your code)

--- a/testdata/src/hooks-named.exclude-attachments.summary.log
+++ b/testdata/src/hooks-named.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 3 steps (3 passed)
 0m 0.9s (0m 0.3s executing your code)

--- a/testdata/src/hooks-named.plain.summary.log
+++ b/testdata/src/hooks-named.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 3 steps (3 passed)
 0m 0.9s (0m 0.3s executing your code)

--- a/testdata/src/hooks-undefined.cucumber.progressbar.log
+++ b/testdata/src/hooks-undefined.cucumber.progressbar.log
@@ -48,7 +48,7 @@
     1) [3mScenario:[23m No tags and a undefined step [90m# samples/hooks-undefined/hooks-undefined.feature:4[39m
          [34m[1mWhen [22ma step does not exist[39m
   
-  1 scenarios ([34m1 undefined[39m)
+  1 scenario ([34m1 undefined[39m)
   3 steps ([32m2 passed[39m, [34m1 undefined[39m)
   0m 0.9s (0m 0.2s executing your code)
   

--- a/testdata/src/hooks-undefined.cucumber.summary.log
+++ b/testdata/src/hooks-undefined.cucumber.summary.log
@@ -3,7 +3,7 @@
   1) No tags and a undefined step [90m# samples/hooks-undefined/hooks-undefined.feature:4[39m
        [34m[1mWhen [22ma step does not exist[39m
 
-1 scenarios ([34m1 undefined[39m)
+1 scenario ([34m1 undefined[39m)
 3 steps ([32m2 passed[39m, [34m1 undefined[39m)
 0m 0.9s (0m 0.2s executing your code)
 

--- a/testdata/src/hooks-undefined.exclude-attachments.summary.log
+++ b/testdata/src/hooks-undefined.exclude-attachments.summary.log
@@ -3,7 +3,7 @@ Undefined scenarios:
   1) No tags and a undefined step # samples/hooks-undefined/hooks-undefined.feature:4
        When a step does not exist
 
-1 scenarios (1 undefined)
+1 scenario (1 undefined)
 3 steps (2 passed, 1 undefined)
 0m 0.9s (0m 0.2s executing your code)
 

--- a/testdata/src/hooks-undefined.plain.summary.log
+++ b/testdata/src/hooks-undefined.plain.summary.log
@@ -3,7 +3,7 @@ Undefined scenarios:
   1) No tags and a undefined step # samples/hooks-undefined/hooks-undefined.feature:4
        When a step does not exist
 
-1 scenarios (1 undefined)
+1 scenario (1 undefined)
 3 steps (2 passed, 1 undefined)
 0m 0.9s (0m 0.2s executing your code)
 

--- a/testdata/src/minimal.cucumber.progressbar.log
+++ b/testdata/src/minimal.cucumber.progressbar.log
@@ -30,7 +30,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([32m1 passed[39m)
-  1 steps ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
+  1 step ([32m1 passed[39m)
   0m 0.5s (0m 0.1s executing your code)
   

--- a/testdata/src/minimal.cucumber.summary.log
+++ b/testdata/src/minimal.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([32m1 passed[39m)
-1 steps ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
+1 step ([32m1 passed[39m)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/minimal.exclude-attachments.summary.log
+++ b/testdata/src/minimal.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/minimal.plain.summary.log
+++ b/testdata/src/minimal.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/parameter-types.cucumber.progressbar.log
+++ b/testdata/src/parameter-types.cucumber.progressbar.log
@@ -30,7 +30,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([32m1 passed[39m)
-  1 steps ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
+  1 step ([32m1 passed[39m)
   0m 0.5s (0m 0.1s executing your code)
   

--- a/testdata/src/parameter-types.cucumber.summary.log
+++ b/testdata/src/parameter-types.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([32m1 passed[39m)
-1 steps ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
+1 step ([32m1 passed[39m)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/parameter-types.exclude-attachments.summary.log
+++ b/testdata/src/parameter-types.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/parameter-types.plain.summary.log
+++ b/testdata/src/parameter-types.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/pending-exception.cucumber.progressbar.log
+++ b/testdata/src/pending-exception.cucumber.progressbar.log
@@ -38,7 +38,7 @@
          [36m[1mGiven [22man unimplemented pending step[39m [90m# samples/pending-exception/pending-exception.ts:3[39m
              [36mTODO[39m
   
-  1 scenarios ([36m1 pending[39m)
-  1 steps ([36m1 pending[39m)
+  1 scenario ([36m1 pending[39m)
+  1 step ([36m1 pending[39m)
   0m 0.5s (0m 0.1s executing your code)
   

--- a/testdata/src/pending-exception.cucumber.summary.log
+++ b/testdata/src/pending-exception.cucumber.summary.log
@@ -4,6 +4,6 @@
        [36m[1mGiven [22man unimplemented pending step[39m [90m# samples/pending-exception/pending-exception.ts:3[39m
            [36mTODO[39m
 
-1 scenarios ([36m1 pending[39m)
-1 steps ([36m1 pending[39m)
+1 scenario ([36m1 pending[39m)
+1 step ([36m1 pending[39m)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/pending-exception.exclude-attachments.summary.log
+++ b/testdata/src/pending-exception.exclude-attachments.summary.log
@@ -4,6 +4,6 @@ Pending scenarios:
        Given an unimplemented pending step # samples/pending-exception/pending-exception.ts:3
            TODO
 
-1 scenarios (1 pending)
-1 steps (1 pending)
+1 scenario (1 pending)
+1 step (1 pending)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/pending-exception.plain.summary.log
+++ b/testdata/src/pending-exception.plain.summary.log
@@ -4,6 +4,6 @@ Pending scenarios:
        Given an unimplemented pending step # samples/pending-exception/pending-exception.ts:3
            TODO
 
-1 scenarios (1 pending)
-1 steps (1 pending)
+1 scenario (1 pending)
+1 step (1 pending)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/regular-expression.cucumber.progressbar.log
+++ b/testdata/src/regular-expression.cucumber.progressbar.log
@@ -42,7 +42,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
   3 steps ([32m3 passed[39m)
   0m 0.9s (0m 0.3s executing your code)
   

--- a/testdata/src/regular-expression.cucumber.summary.log
+++ b/testdata/src/regular-expression.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
 3 steps ([32m3 passed[39m)
 0m 0.9s (0m 0.3s executing your code)

--- a/testdata/src/regular-expression.exclude-attachments.summary.log
+++ b/testdata/src/regular-expression.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 3 steps (3 passed)
 0m 0.9s (0m 0.3s executing your code)

--- a/testdata/src/regular-expression.plain.summary.log
+++ b/testdata/src/regular-expression.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
+1 scenario (1 passed)
 3 steps (3 passed)
 0m 0.9s (0m 0.3s executing your code)

--- a/testdata/src/retry-ambiguous.cucumber.progressbar.log
+++ b/testdata/src/retry-ambiguous.cucumber.progressbar.log
@@ -42,7 +42,7 @@
                • an ambiguous step [90m# samples/retry-ambiguous/retry-ambiguous.ts:3[39m
                • an ambiguous step [90m# samples/retry-ambiguous/retry-ambiguous.ts:7[39m
   
-  1 scenarios ([35m1 ambiguous[39m)
-  1 steps ([35m1 ambiguous[39m)
+  1 scenario ([35m1 ambiguous[39m)
+  1 step ([35m1 ambiguous[39m)
   0m 0.5s (0m 0.0s executing your code)
   

--- a/testdata/src/retry-ambiguous.cucumber.summary.log
+++ b/testdata/src/retry-ambiguous.cucumber.summary.log
@@ -6,6 +6,6 @@
              • an ambiguous step [90m# samples/retry-ambiguous/retry-ambiguous.ts:3[39m
              • an ambiguous step [90m# samples/retry-ambiguous/retry-ambiguous.ts:7[39m
 
-1 scenarios ([35m1 ambiguous[39m)
-1 steps ([35m1 ambiguous[39m)
+1 scenario ([35m1 ambiguous[39m)
+1 step ([35m1 ambiguous[39m)
 0m 0.5s (0m 0.0s executing your code)

--- a/testdata/src/retry-ambiguous.exclude-attachments.summary.log
+++ b/testdata/src/retry-ambiguous.exclude-attachments.summary.log
@@ -6,6 +6,6 @@ Ambiguous scenarios:
              - an ambiguous step # samples/retry-ambiguous/retry-ambiguous.ts:3
              - an ambiguous step # samples/retry-ambiguous/retry-ambiguous.ts:7
 
-1 scenarios (1 ambiguous)
-1 steps (1 ambiguous)
+1 scenario (1 ambiguous)
+1 step (1 ambiguous)
 0m 0.5s (0m 0.0s executing your code)

--- a/testdata/src/retry-ambiguous.plain.summary.log
+++ b/testdata/src/retry-ambiguous.plain.summary.log
@@ -6,6 +6,6 @@ Ambiguous scenarios:
              - an ambiguous step # samples/retry-ambiguous/retry-ambiguous.ts:3
              - an ambiguous step # samples/retry-ambiguous/retry-ambiguous.ts:7
 
-1 scenarios (1 ambiguous)
-1 steps (1 ambiguous)
+1 scenario (1 ambiguous)
+1 step (1 ambiguous)
 0m 0.5s (0m 0.0s executing your code)

--- a/testdata/src/retry-pending.cucumber.progressbar.log
+++ b/testdata/src/retry-pending.cucumber.progressbar.log
@@ -36,7 +36,7 @@
     1) [3mScenario:[23m Test cases won't retry when the status is PENDING [90m# samples/retry-pending/retry-pending.feature:2[39m
          [36m[1mGiven [22ma pending step[39m [90m# samples/retry-pending/retry-pending.ts:3[39m
   
-  1 scenarios ([36m1 pending[39m)
-  1 steps ([36m1 pending[39m)
+  1 scenario ([36m1 pending[39m)
+  1 step ([36m1 pending[39m)
   0m 0.5s (0m 0.1s executing your code)
   

--- a/testdata/src/retry-pending.cucumber.summary.log
+++ b/testdata/src/retry-pending.cucumber.summary.log
@@ -3,6 +3,6 @@
   1) Test cases won't retry when the status is PENDING [90m# samples/retry-pending/retry-pending.feature:2[39m
        [36m[1mGiven [22ma pending step[39m [90m# samples/retry-pending/retry-pending.ts:3[39m
 
-1 scenarios ([36m1 pending[39m)
-1 steps ([36m1 pending[39m)
+1 scenario ([36m1 pending[39m)
+1 step ([36m1 pending[39m)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/retry-pending.exclude-attachments.summary.log
+++ b/testdata/src/retry-pending.exclude-attachments.summary.log
@@ -3,6 +3,6 @@ Pending scenarios:
   1) Test cases won't retry when the status is PENDING # samples/retry-pending/retry-pending.feature:2
        Given a pending step # samples/retry-pending/retry-pending.ts:3
 
-1 scenarios (1 pending)
-1 steps (1 pending)
+1 scenario (1 pending)
+1 step (1 pending)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/retry-pending.plain.summary.log
+++ b/testdata/src/retry-pending.plain.summary.log
@@ -3,6 +3,6 @@ Pending scenarios:
   1) Test cases won't retry when the status is PENDING # samples/retry-pending/retry-pending.feature:2
        Given a pending step # samples/retry-pending/retry-pending.ts:3
 
-1 scenarios (1 pending)
-1 steps (1 pending)
+1 scenario (1 pending)
+1 step (1 pending)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/retry-undefined.cucumber.progressbar.log
+++ b/testdata/src/retry-undefined.cucumber.progressbar.log
@@ -36,8 +36,8 @@
     1) [3mScenario:[23m Test cases won't retry when the status is UNDEFINED [90m# samples/retry-undefined/retry-undefined.feature:2[39m
          [34m[1mGiven [22ma non-existent step[39m
   
-  1 scenarios ([34m1 undefined[39m)
-  1 steps ([34m1 undefined[39m)
+  1 scenario ([34m1 undefined[39m)
+  1 step ([34m1 undefined[39m)
   0m 0.5s (0m 0.0s executing your code)
   
   You can implement missing steps with the snippets below:

--- a/testdata/src/retry-undefined.cucumber.summary.log
+++ b/testdata/src/retry-undefined.cucumber.summary.log
@@ -3,8 +3,8 @@
   1) Test cases won't retry when the status is UNDEFINED [90m# samples/retry-undefined/retry-undefined.feature:2[39m
        [34m[1mGiven [22ma non-existent step[39m
 
-1 scenarios ([34m1 undefined[39m)
-1 steps ([34m1 undefined[39m)
+1 scenario ([34m1 undefined[39m)
+1 step ([34m1 undefined[39m)
 0m 0.5s (0m 0.0s executing your code)
 
 You can implement missing steps with the snippets below:

--- a/testdata/src/retry-undefined.exclude-attachments.summary.log
+++ b/testdata/src/retry-undefined.exclude-attachments.summary.log
@@ -3,8 +3,8 @@ Undefined scenarios:
   1) Test cases won't retry when the status is UNDEFINED # samples/retry-undefined/retry-undefined.feature:2
        Given a non-existent step
 
-1 scenarios (1 undefined)
-1 steps (1 undefined)
+1 scenario (1 undefined)
+1 step (1 undefined)
 0m 0.5s (0m 0.0s executing your code)
 
 You can implement missing steps with the snippets below:

--- a/testdata/src/retry-undefined.plain.summary.log
+++ b/testdata/src/retry-undefined.plain.summary.log
@@ -3,8 +3,8 @@ Undefined scenarios:
   1) Test cases won't retry when the status is UNDEFINED # samples/retry-undefined/retry-undefined.feature:2
        Given a non-existent step
 
-1 scenarios (1 undefined)
-1 steps (1 undefined)
+1 scenario (1 undefined)
+1 step (1 undefined)
 0m 0.5s (0m 0.0s executing your code)
 
 You can implement missing steps with the snippets below:

--- a/testdata/src/skipped-exception.cucumber.progressbar.log
+++ b/testdata/src/skipped-exception.cucumber.progressbar.log
@@ -30,7 +30,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([33m1 skipped[39m)
-  1 steps ([33m1 skipped[39m)
+  1 scenario ([33m1 skipped[39m)
+  1 step ([33m1 skipped[39m)
   0m 0.5s (0m 0.1s executing your code)
   

--- a/testdata/src/skipped-exception.cucumber.summary.log
+++ b/testdata/src/skipped-exception.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([33m1 skipped[39m)
-1 steps ([33m1 skipped[39m)
+1 scenario ([33m1 skipped[39m)
+1 step ([33m1 skipped[39m)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/skipped-exception.exclude-attachments.summary.log
+++ b/testdata/src/skipped-exception.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 skipped)
-1 steps (1 skipped)
+1 scenario (1 skipped)
+1 step (1 skipped)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/skipped-exception.plain.summary.log
+++ b/testdata/src/skipped-exception.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 skipped)
-1 steps (1 skipped)
+1 scenario (1 skipped)
+1 step (1 skipped)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/skipped-failing-hook.cucumber.progressbar.log
+++ b/testdata/src/skipped-failing-hook.cucumber.progressbar.log
@@ -48,7 +48,7 @@
              [31mError: whoops[39m
              [31msamples/skipped-failing-hook/skipped-failing-hook.feature:6[39m
   
-  1 scenarios ([31m1 failed[39m)
+  1 scenario ([31m1 failed[39m)
   2 steps ([33m1 skipped[39m, [31m1 failed[39m)
   0m 0.7s (0m 0.2s executing your code)
   

--- a/testdata/src/skipped-failing-hook.cucumber.summary.log
+++ b/testdata/src/skipped-failing-hook.cucumber.summary.log
@@ -6,6 +6,6 @@
            [31mError: whoops[39m
            [31msamples/skipped-failing-hook/skipped-failing-hook.feature:6[39m
 
-1 scenarios ([31m1 failed[39m)
+1 scenario ([31m1 failed[39m)
 2 steps ([33m1 skipped[39m, [31m1 failed[39m)
 0m 0.7s (0m 0.2s executing your code)

--- a/testdata/src/skipped-failing-hook.exclude-attachments.summary.log
+++ b/testdata/src/skipped-failing-hook.exclude-attachments.summary.log
@@ -6,6 +6,6 @@ Failed scenarios:
            Error: whoops
            samples/skipped-failing-hook/skipped-failing-hook.feature:6
 
-1 scenarios (1 failed)
+1 scenario (1 failed)
 2 steps (1 skipped, 1 failed)
 0m 0.7s (0m 0.2s executing your code)

--- a/testdata/src/skipped-failing-hook.plain.summary.log
+++ b/testdata/src/skipped-failing-hook.plain.summary.log
@@ -6,6 +6,6 @@ Failed scenarios:
            Error: whoops
            samples/skipped-failing-hook/skipped-failing-hook.feature:6
 
-1 scenarios (1 failed)
+1 scenario (1 failed)
 2 steps (1 skipped, 1 failed)
 0m 0.7s (0m 0.2s executing your code)

--- a/testdata/src/stack-traces.cucumber.progressbar.log
+++ b/testdata/src/stack-traces.cucumber.progressbar.log
@@ -40,7 +40,7 @@
              [31mError: BOOM[39m
              [31msamples/stack-traces/stack-traces.feature:10[39m
   
-  1 scenarios ([31m1 failed[39m)
-  1 steps ([31m1 failed[39m)
+  1 scenario ([31m1 failed[39m)
+  1 step ([31m1 failed[39m)
   0m 0.5s (0m 0.1s executing your code)
   

--- a/testdata/src/stack-traces.cucumber.summary.log
+++ b/testdata/src/stack-traces.cucumber.summary.log
@@ -5,6 +5,6 @@
            [31mError: BOOM[39m
            [31msamples/stack-traces/stack-traces.feature:10[39m
 
-1 scenarios ([31m1 failed[39m)
-1 steps ([31m1 failed[39m)
+1 scenario ([31m1 failed[39m)
+1 step ([31m1 failed[39m)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/stack-traces.exclude-attachments.summary.log
+++ b/testdata/src/stack-traces.exclude-attachments.summary.log
@@ -5,6 +5,6 @@ Failed scenarios:
            Error: BOOM
            samples/stack-traces/stack-traces.feature:10
 
-1 scenarios (1 failed)
-1 steps (1 failed)
+1 scenario (1 failed)
+1 step (1 failed)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/stack-traces.plain.summary.log
+++ b/testdata/src/stack-traces.plain.summary.log
@@ -5,6 +5,6 @@ Failed scenarios:
            Error: BOOM
            samples/stack-traces/stack-traces.feature:10
 
-1 scenarios (1 failed)
-1 steps (1 failed)
+1 scenario (1 failed)
+1 step (1 failed)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/unknown-parameter-type.cucumber.progressbar.log
+++ b/testdata/src/unknown-parameter-type.cucumber.progressbar.log
@@ -46,8 +46,8 @@
     2) [3mScenario:[23m undefined parameter type [90m# samples/unknown-parameter-type/unknown-parameter-type.feature:6[39m
          [34m[1mGiven [22mCDG is closed because of a strike[39m
   
-  1 scenarios ([34m1 undefined[39m)
-  1 steps ([34m1 undefined[39m)
+  1 scenario ([34m1 undefined[39m)
+  1 step ([34m1 undefined[39m)
   0m 0.5s (0m 0.0s executing your code)
   
   You can implement missing steps with the snippets below:

--- a/testdata/src/unknown-parameter-type.cucumber.summary.log
+++ b/testdata/src/unknown-parameter-type.cucumber.summary.log
@@ -6,8 +6,8 @@
 [34mThese parameters are missing a parameter type definition:[39m
   1) 'airport' in '{airport} is closed because of a strike'
 
-1 scenarios ([34m1 undefined[39m)
-1 steps ([34m1 undefined[39m)
+1 scenario ([34m1 undefined[39m)
+1 step ([34m1 undefined[39m)
 0m 0.5s (0m 0.0s executing your code)
 
 You can implement missing steps with the snippets below:

--- a/testdata/src/unknown-parameter-type.exclude-attachments.summary.log
+++ b/testdata/src/unknown-parameter-type.exclude-attachments.summary.log
@@ -6,8 +6,8 @@ Undefined scenarios:
 These parameters are missing a parameter type definition:
   1) 'airport' in '{airport} is closed because of a strike'
 
-1 scenarios (1 undefined)
-1 steps (1 undefined)
+1 scenario (1 undefined)
+1 step (1 undefined)
 0m 0.5s (0m 0.0s executing your code)
 
 You can implement missing steps with the snippets below:

--- a/testdata/src/unknown-parameter-type.plain.summary.log
+++ b/testdata/src/unknown-parameter-type.plain.summary.log
@@ -6,8 +6,8 @@ Undefined scenarios:
 These parameters are missing a parameter type definition:
   1) 'airport' in '{airport} is closed because of a strike'
 
-1 scenarios (1 undefined)
-1 steps (1 undefined)
+1 scenario (1 undefined)
+1 step (1 undefined)
 0m 0.5s (0m 0.0s executing your code)
 
 You can implement missing steps with the snippets below:

--- a/testdata/src/unused-steps.cucumber.progressbar.log
+++ b/testdata/src/unused-steps.cucumber.progressbar.log
@@ -30,7 +30,7 @@
   
 [testRunFinished]
   
-  1 scenarios ([32m1 passed[39m)
-  1 steps ([32m1 passed[39m)
+  1 scenario ([32m1 passed[39m)
+  1 step ([32m1 passed[39m)
   0m 0.5s (0m 0.1s executing your code)
   

--- a/testdata/src/unused-steps.cucumber.summary.log
+++ b/testdata/src/unused-steps.cucumber.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios ([32m1 passed[39m)
-1 steps ([32m1 passed[39m)
+1 scenario ([32m1 passed[39m)
+1 step ([32m1 passed[39m)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/unused-steps.exclude-attachments.summary.log
+++ b/testdata/src/unused-steps.exclude-attachments.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.5s (0m 0.1s executing your code)

--- a/testdata/src/unused-steps.plain.summary.log
+++ b/testdata/src/unused-steps.plain.summary.log
@@ -1,4 +1,4 @@
 
-1 scenarios (1 passed)
-1 steps (1 passed)
+1 scenario (1 passed)
+1 step (1 passed)
 0m 0.5s (0m 0.1s executing your code)


### PR DESCRIPTION
### 🤔 What's changed?

Print either the singular or plural of nouns like "scenario" and "step" depending on the count.

### ⚡️ What's your motivation? 

Fixes #99.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
