### PR TITLE
Only normalize EOL of expected output

### DIFF
--- a/javascript/src/PrettyPrinter.spec.ts
+++ b/javascript/src/PrettyPrinter.spec.ts
@@ -118,7 +118,7 @@ describe('PrettyPrinter', async () => {
             encoding: 'utf-8',
           })
 
-          expect(normalizeEol(stream.content)).to.eq(normalizeEol(expectedOutput))
+          expect(stream.content).to.eq(normalizeEol(expectedOutput))
         })
       }
     })
@@ -166,7 +166,7 @@ describe('PrettyPrinter', async () => {
         { encoding: 'utf-8' }
       )
 
-      expect(normalizeEol(stream.content)).to.eq(normalizeEol(expectedPretty + expectedSummary))
+      expect(stream.content).to.eq(normalizeEol(expectedPretty + expectedSummary))
     })
   })
 })

--- a/javascript/src/ProgressBarPrinter.spec.ts
+++ b/javascript/src/ProgressBarPrinter.spec.ts
@@ -159,7 +159,9 @@ describe('ProgressBarPrinter', () => {
       const capturedLog = stream.content
       const fullOutputPath = ndjsonFile.replace('.ndjson', '.cucumber.progressbar.log')
       const fullOutputContent = fs.readFileSync(fullOutputPath, { encoding: 'utf-8' })
-      expect(normalizeEol(fullOutputContent)).to.include(`[testRunFinished]\n${indent(capturedLog, 2)}`)
+      expect(normalizeEol(fullOutputContent)).to.include(
+        `[testRunFinished]\n${indent(capturedLog, 2)}`
+      )
     })
 
     it('restores the original write after the run finishes', () => {

--- a/javascript/src/ProgressBarPrinter.spec.ts
+++ b/javascript/src/ProgressBarPrinter.spec.ts
@@ -100,8 +100,8 @@ describe('ProgressBarPrinter', () => {
     const capturedLog = stream.content
     const fullOutputPath = ndjsonFile.replace('.ndjson', '.cucumber.progressbar.log')
     const fullOutputContent = fs.readFileSync(fullOutputPath, { encoding: 'utf-8' })
-    expect(fullOutputContent).to.include(
-      normalizeEol(`[testRunFinished]\n${indent(capturedLog, 2)}`)
+    expect(normalizeEol(fullOutputContent)).to.include(
+      `[testRunFinished]\n${indent(capturedLog, 2)}`
     )
   })
 

--- a/javascript/src/ProgressBarPrinter.spec.ts
+++ b/javascript/src/ProgressBarPrinter.spec.ts
@@ -159,7 +159,7 @@ describe('ProgressBarPrinter', () => {
       const capturedLog = stream.content
       const fullOutputPath = ndjsonFile.replace('.ndjson', '.cucumber.progressbar.log')
       const fullOutputContent = fs.readFileSync(fullOutputPath, { encoding: 'utf-8' })
-      expect(fullOutputContent).to.include(`[testRunFinished]\n${indent(capturedLog, 2)}`)
+      expect(normalizeEol(fullOutputContent)).to.include(`[testRunFinished]\n${indent(capturedLog, 2)}`)
     })
 
     it('restores the original write after the run finishes', () => {

--- a/javascript/src/ProgressBarPrinter.spec.ts
+++ b/javascript/src/ProgressBarPrinter.spec.ts
@@ -159,7 +159,9 @@ describe('ProgressBarPrinter', () => {
       const capturedLog = stream.content
       const fullOutputPath = ndjsonFile.replace('.ndjson', '.cucumber.progressbar.log')
       const fullOutputContent = fs.readFileSync(fullOutputPath, { encoding: 'utf-8' })
-      expect(fullOutputContent).to.include(`[testRunFinished]\n${indent(capturedLog, 2)}`)
+      expect(normalizeEol(fullOutputContent)).to.include(
+        `[testRunFinished]\n${indent(capturedLog, 2)}`
+      )
     })
 
     it('restores the original write after the run finishes', () => {

--- a/javascript/src/ProgressBarPrinter.spec.ts
+++ b/javascript/src/ProgressBarPrinter.spec.ts
@@ -60,7 +60,7 @@ describe('ProgressBarPrinter', () => {
         }
         const expectedOutput = fs.readFileSync(expectedPath, { encoding: 'utf-8' })
 
-        expect(normalizeEol(capturedLog)).to.eq(normalizeEol(expectedOutput))
+        expect(capturedLog).to.eq(normalizeEol(expectedOutput))
       })
     }
   })
@@ -100,7 +100,7 @@ describe('ProgressBarPrinter', () => {
     const capturedLog = stream.content
     const fullOutputPath = ndjsonFile.replace('.ndjson', '.cucumber.progressbar.log')
     const fullOutputContent = fs.readFileSync(fullOutputPath, { encoding: 'utf-8' })
-    expect(normalizeEol(fullOutputContent)).to.include(
+    expect(fullOutputContent).to.include(
       normalizeEol(`[testRunFinished]\n${indent(capturedLog, 2)}`)
     )
   })
@@ -159,9 +159,7 @@ describe('ProgressBarPrinter', () => {
       const capturedLog = stream.content
       const fullOutputPath = ndjsonFile.replace('.ndjson', '.cucumber.progressbar.log')
       const fullOutputContent = fs.readFileSync(fullOutputPath, { encoding: 'utf-8' })
-      expect(normalizeEol(fullOutputContent)).to.include(
-        `[testRunFinished]\n${indent(capturedLog, 2)}`
-      )
+      expect(fullOutputContent).to.include(`[testRunFinished]\n${indent(capturedLog, 2)}`)
     })
 
     it('restores the original write after the run finishes', () => {

--- a/javascript/src/ProgressPrinter.spec.ts
+++ b/javascript/src/ProgressPrinter.spec.ts
@@ -70,7 +70,7 @@ describe('ProgressPrinter', async () => {
             encoding: 'utf-8',
           })
 
-          expect(normalizeEol(stream.content)).to.eq(normalizeEol(expectedOutput))
+          expect(stream.content).to.eq(normalizeEol(expectedOutput))
         })
       }
     })
@@ -118,7 +118,7 @@ describe('ProgressPrinter', async () => {
         { encoding: 'utf-8' }
       )
 
-      expect(normalizeEol(stream.content)).to.eq(normalizeEol(expectedProgress + expectedSummary))
+      expect(stream.content).to.eq(normalizeEol(expectedProgress + expectedSummary))
     })
   })
 })

--- a/javascript/src/SummaryPrinter.spec.ts
+++ b/javascript/src/SummaryPrinter.spec.ts
@@ -77,7 +77,7 @@ describe('SummaryPrinter', async () => {
             encoding: 'utf-8',
           })
 
-          expect(normalizeEol(stream.content)).to.eq(normalizeEol(expectedOutput))
+          expect(stream.content).to.eq(normalizeEol(expectedOutput))
         })
       }
     })


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Closes: https://github.com/cucumber/pretty-formatter/issues/113

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
